### PR TITLE
Always preserve LF in .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
On my windows machine I have enabled`core.autocrlf` in git. So when I checkout the repository all `*.sh` scripts `lf` are replaced with `\r\n` (0x0D, 0x0A). Then when I try to `docker compose up -d`, .sh scripts fails due to `\r`.

Adding a `.gitattributes` with `*.sh text eol=lf` should fix it. Next time other user checkouts the repository `*.sh` will remain unchanged.