### PR TITLE
Bump pricing4ts to ^0.11.1 so Pricing2Yaml 3.1 can be registered

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -58,7 +58,7 @@
     "multer": "1.4.5-lts.2",
     "nock": "^14.0.10",
     "node-fetch": "^3.3.2",
-    "pricing4ts": "^0.10.3",
+    "pricing4ts": "^0.11.1",
     "redis": "^4.7.0",
     "socket.io": "^4.8.1",
     "uuid": "^11.1.0"

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       pricing4ts:
-        specifier: ^0.10.3
-        version: 0.10.3(@openfeature/core@1.8.0)(minizinc@4.4.3)
+        specifier: ^0.11.1
+        version: 0.11.1(@openfeature/core@1.8.0)(minizinc@4.4.3)
       redis:
         specifier: ^4.7.0
         version: 4.7.1
@@ -1783,8 +1783,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  pricing4ts@0.10.3:
-    resolution: {integrity: sha512-RU9s3RvU7u3jByJsciihDZgF3XQCi2GWCyqMwU6wB+Hx/oRO5Wq+FidCYQadgExDMwD9KAkP/AXIPUCnolk95Q==}
+  pricing4ts@0.11.1:
+    resolution: {integrity: sha512-Q2lTrkhvgAGyefr9dh1qN7XL3hQ+NdU5OGHjD00yHMB2YOnbfV3gMfpc5hkaxjd93R1OGUqnfExQlHxesAq0wg==}
     peerDependencies:
       minizinc: ^4.3.5
 
@@ -2124,6 +2124,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -3940,7 +3941,7 @@ snapshots:
 
   prettier@3.5.3: {}
 
-  pricing4ts@0.10.3(@openfeature/core@1.8.0)(minizinc@4.4.3):
+  pricing4ts@0.11.1(@openfeature/core@1.8.0)(minizinc@4.4.3):
     dependencies:
       '@openfeature/server-sdk': 1.18.0(@openfeature/core@1.8.0)
       '@types/papaparse': 5.3.16


### PR DESCRIPTION
## What this changes

`api/package.json`: `pricing4ts` `^0.10.3` → `^0.11.1`.

One line, plus the lockfile. No source file changes.

## Why

0.10.3 stops one version short of the current specification:

```js
// pricing4ts@0.10.3 – dist/server/utils/version-manager.js
exports.PRICING2YAML_VERSIONS = ["1.0", "1.1", "2.0", "2.1", "3.0"];

// pricing4ts@0.11.1
exports.PRICING2YAML_VERSIONS = ["1.0", "1.1", "2.0", "2.1", "3.0", "3.1"];
```

So a service registering a pricing written against Pricing2Yaml 3.1 is refused
by a running SPACE:

```
Unsupported version: 3.1. Please, visit the changelogs of Pricing2Yaml to check
the supported versions.
```

The only way to register anything today is to declare `syntaxVersion: '3.0'`
and stay a version behind — which is what our own pricing has been carrying,
with a comment explaining why.

## Verification

**The parser.** Same document, same call, both versions:

```
pricing4ts 0.11.1 (this PR):  PARSED -> saas: openbinding | plans: FREE, PRO
pricing4ts 0.10.3 (on main):  REFUSED: Unsupported version: 3.1…
```

**The build.** `pnpm run build` (`tsc`) passes. SPACE imports
`retrievePricingFromPath`, `retrievePricingFromText` and the
`Pricing`/`Plan`/`Feature`/`UsageLimit` types; none of their signatures changed
between the two releases.

**The tests**, run per file against a local MongoDB and Redis:

| file | on `main` (0.10.3) | with this PR (0.11.1) |
| --- | --- | --- |
| `service.test.ts` | — | 44 passed |
| `contract.test.ts` | 1 failed, 76 passed | **77 passed** |

So the bump also clears a test that fails on `main` today.

**Correction to an earlier version of this description.** I first wrote here
that the whole suite produced extra failures in `contract.test.ts` on both
branches, and guessed at state shared through the one database. That was wrong,
and the fault was mine: I had been pointing the tests at throwaway containers on
non-default ports while the machine was also building an unrelated project. With
Mongo 7.0.16 on 27017, Redis 7 on 6379 and the machine otherwise idle, the full
suite is clean:

```
✓ user.test.ts (73)            ✓ analytics.test.ts (2)
✓ events.test.ts (5)           ✓ service.disable.test.ts (3)
✓ service.test.ts (44)         ✓ feature-evaluation.test.ts (26)
✓ routeMatcher.test.ts (12)    ✓ contract.test.ts (77)
✓ version-formatter.test.ts (19)  ✓ organization.test.ts (127)
✓ authMiddleware.test.ts (68)  ✓ permissions.test.ts (245)
```

701 tests across 12 files, on `main` and with this PR. The residual failures I
saw were 5000 ms timeouts under load, plus one test that draws a random pricing
file per run. `run-tests.sh` runs each file in its own vitest process, so there
is no cross-file state to worry about.

`run-tests.sh` calls `vitest` directly, which is not on `PATH` after a plain
`pnpm install`; I ran it with `npx vitest` locally and have left that change out
of this PR.

## Note on `syntaxVersion`

The v3.1 specification page documents `syntaxVersion` with "Supported value:
`3.0`", which looks like a documentation error rather than an intended
constraint — `pricing4ts` 0.11.1 accepts `3.1` and lists it as the latest.
Flagging in case it is worth correcting on the docs side too.

