### PR TITLE
A database outage should not be reported as 401 Unauthorized

### DIFF
--- a/api/src/main/middlewares/AuthMiddleware.ts
+++ b/api/src/main/middlewares/AuthMiddleware.ts
@@ -8,6 +8,7 @@ import {
 import { matchPath, extractApiPath } from '../utils/routeMatcher';
 import { LeanOrganization, OrganizationMember, OrganizationUserRole } from '../types/models/Organization';
 import { HttpMethod, OrganizationApiKeyRole } from '../types/permissions';
+import { LeanUser } from '../types/models/User';
 
 /**
  * Middleware to authenticate API Keys (both User and Organization types)
@@ -80,14 +81,41 @@ const authenticateApiKeyMiddleware = async (req: Request, res: Response, next: N
 async function authenticateUserApiKey(req: Request, apiKey: string): Promise<void> {
   const userService = container.resolve('userService');
 
-  const user = await userService.findByApiKey(apiKey);
-
-  if (!user) {
-    throw new InvalidApiKeyError('Invalid User API Key');
-  }
+  const user = await rejectionOrOutage<LeanUser>(
+    () => userService.findByApiKey(apiKey),
+    'Invalid User API Key'
+  );
 
   req.user = user;
   req.authType = 'user';
+}
+
+/**
+ * Run a credential lookup, telling a refusal apart from a failure.
+ *
+ * `UserService.findByApiKey` reports an unknown key by throwing rather than by
+ * returning nothing, using the `INVALID DATA:` prefix this codebase gives to a
+ * caller's own mistake. That has to keep answering 401. Anything else thrown by
+ * a lookup is the database being unable to answer, which is the case this
+ * middleware exists to stop reporting as a bad credential.
+ */
+async function rejectionOrOutage<T>(lookup: () => Promise<T>, absent: string): Promise<T> {
+  let found: T;
+
+  try {
+    found = await lookup();
+  } catch (err: any) {
+    if (typeof err?.message === 'string' && err.message.startsWith('INVALID DATA:')) {
+      throw new InvalidApiKeyError(err.message);
+    }
+    throw err;
+  }
+
+  if (!found) {
+    throw new InvalidApiKeyError(absent);
+  }
+
+  return found;
 }
 
 /**
@@ -97,11 +125,10 @@ async function authenticateOrgApiKey(req: Request, apiKey: string): Promise<void
   const organizationRepository = container.resolve('organizationRepository');
 
   // Find organization by API Key
-  const result: LeanOrganization = await organizationRepository.findByApiKey(apiKey);
-
-  if (!result) {
-    throw new InvalidApiKeyError('Invalid Organization API Key');
-  }
+  const result: LeanOrganization = await rejectionOrOutage(
+    () => organizationRepository.findByApiKey(apiKey),
+    'Invalid Organization API Key'
+  );
 
   req.org = {
     id: result.id!,

--- a/api/src/main/middlewares/AuthMiddleware.ts
+++ b/api/src/main/middlewares/AuthMiddleware.ts
@@ -19,6 +19,18 @@ import { HttpMethod, OrganizationApiKeyRole } from '../types/permissions';
  * Sets req.user for User API Keys
  * Sets req.org for Organization API Keys
  */
+/**
+ * A credential that was read and found wanting.
+ *
+ * Distinguished from every other failure on purpose. Authentication reads the
+ * database, so anything that can go wrong with the database - a dropped
+ * connection, a replica-set election, a Mongo that is simply not running -
+ * surfaces as an exception here too. Answering 401 to those says the caller
+ * sent a bad key, which is untrue and sends whoever is debugging to look at
+ * their credentials.
+ */
+class InvalidApiKeyError extends Error {}
+
 const authenticateApiKeyMiddleware = async (req: Request, res: Response, next: NextFunction) => {
   const apiKey = req.headers['x-api-key'] as string;
 
@@ -40,11 +52,25 @@ const authenticateApiKeyMiddleware = async (req: Request, res: Response, next: N
 
     return checkPermissions(req, res, next);
   } catch (err: any) {
-    if (!res.headersSent) {
+    if (res.headersSent) {
+      return;
+    }
+
+    if (err instanceof InvalidApiKeyError) {
       return res.status(401).json({
         error: err.message || 'Invalid API Key',
       });
     }
+
+    // Anything else got as far as trying and could not finish - almost always
+    // the database. 503 rather than 401, because the credential was never
+    // judged, and Retry-After because it is worth trying again.
+    console.error('Authentication could not be completed:', err);
+    res.setHeader('Retry-After', '5');
+    return res.status(503).json({
+      error: 'Space cannot verify credentials right now.',
+      details: err?.message ?? String(err),
+    });
   }
 };
 
@@ -57,7 +83,7 @@ async function authenticateUserApiKey(req: Request, apiKey: string): Promise<voi
   const user = await userService.findByApiKey(apiKey);
 
   if (!user) {
-    throw new Error('Invalid User API Key');
+    throw new InvalidApiKeyError('Invalid User API Key');
   }
 
   req.user = user;
@@ -74,7 +100,7 @@ async function authenticateOrgApiKey(req: Request, apiKey: string): Promise<void
   const result: LeanOrganization = await organizationRepository.findByApiKey(apiKey);
 
   if (!result) {
-    throw new Error('Invalid Organization API Key');
+    throw new InvalidApiKeyError('Invalid Organization API Key');
   }
 
   req.org = {

--- a/api/src/main/routes/HealthcheckRoutes.ts
+++ b/api/src/main/routes/HealthcheckRoutes.ts
@@ -1,18 +1,49 @@
 import express from 'express';
+import mongoose from 'mongoose';
+
+/**
+ * Mongoose reports 1 when the driver has a usable connection.
+ *
+ * 2 is "still connecting", which matters at start-up: a container answering
+ * "healthy" while it is still dialling is one an orchestrator will start
+ * sending traffic to.
+ */
+const CONNECTED = 1;
 
 const loadFileRoutes = function (app: express.Application) {
   const baseUrl = '/api/v1';
 
   // Public route for authentication (does not require API Key)
-  app
-    .route(`${baseUrl}/healthcheck`)
-    .get(
-      (req: any, res: any) => {
-        res.status(200).json({
-          message: 'Service is up and running!',
-        });
-      }
-    );
+  app.route(`${baseUrl}/healthcheck`).get(async (req: any, res: any) => {
+    // The database is not a detail of this service, it is the service: every
+    // authenticated route reads it before it can answer anything. A check that
+    // proves only the HTTP listener is up reports a Space that cannot serve a
+    // single request as healthy, and keeps reporting it indefinitely while
+    // every call fails.
+    if (mongoose.connection.readyState !== CONNECTED) {
+      return res.status(503).json({
+        message: 'Service is up but cannot reach its database.',
+        database: 'disconnected',
+      });
+    }
+
+    try {
+      // readyState is what the driver believes. A ping is what the database
+      // says, and the two disagree when a connection has gone stale.
+      await mongoose.connection.db!.admin().ping();
+    } catch (error: any) {
+      return res.status(503).json({
+        message: 'Service is up but its database is not answering.',
+        database: 'unreachable',
+        details: error?.message ?? String(error),
+      });
+    }
+
+    res.status(200).json({
+      message: 'Service is up and running!',
+      database: 'connected',
+    });
+  });
 };
 
 export default loadFileRoutes;

--- a/api/src/test/middlewares/authOutage.test.ts
+++ b/api/src/test/middlewares/authOutage.test.ts
@@ -1,0 +1,93 @@
+import request from 'supertest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { Server } from 'http';
+import { getApp, shutdownApp, baseUrl } from '../utils/testApp';
+import { createTestUser, deleteTestUser } from '../utils/users/userTestUtils';
+import container from '../../main/config/container';
+import { LeanUser } from '../../main/types/models/User';
+
+/**
+ * Telling "your key is wrong" apart from "we could not check your key".
+ *
+ * Authentication reads the database, so a dropped connection, a replica-set
+ * election or a Mongo that is simply not running all surface as an exception in
+ * the same place an unknown key does. Answering 401 to those states something
+ * untrue about the caller's credential and sends whoever is debugging to look
+ * at their API key, which is the one place the problem is not.
+ *
+ * Both directions are pinned here, because the interesting part of the change
+ * is the boundary: a refusal must stay a refusal.
+ */
+describe('Authentication when the database cannot answer', function () {
+  let app: Server;
+  let user: LeanUser;
+
+  beforeAll(async function () {
+    app = await getApp();
+    user = await createTestUser('ADMIN');
+  });
+
+  afterAll(async function () {
+    await deleteTestUser(user.username);
+    vi.restoreAllMocks();
+    await shutdownApp();
+  });
+
+  it('answers 503, not 401, when the lookup fails', async function () {
+    const userService: any = container.resolve('userService');
+    const outage = vi
+      .spyOn(userService, 'findByApiKey')
+      .mockRejectedValue(new Error('MongooseServerSelectionError: connection timed out'));
+
+    try {
+      const response = await request(app)
+        .get(`${baseUrl}/users`)
+        .set('x-api-key', user.apiKey);
+
+      expect(response.status).toBe(503);
+      expect(response.body.error).toContain('cannot verify credentials');
+    } finally {
+      outage.mockRestore();
+    }
+  });
+
+  it('asks the caller to try again', async function () {
+    const userService: any = container.resolve('userService');
+    const outage = vi
+      .spyOn(userService, 'findByApiKey')
+      .mockRejectedValue(new Error('MongooseServerSelectionError: connection timed out'));
+
+    try {
+      const response = await request(app)
+        .get(`${baseUrl}/users`)
+        .set('x-api-key', user.apiKey);
+
+      // A 503 without Retry-After tells a client nothing about whether waiting
+      // is worth it.
+      expect(response.headers['retry-after']).toBeDefined();
+    } finally {
+      outage.mockRestore();
+    }
+  });
+
+  it('still answers 401 to a key that was read and rejected', async function () {
+    // The regression this pairs with. `UserService.findByApiKey` reports an
+    // unknown key by throwing rather than by returning nothing, so narrowing
+    // the catch to a dedicated error type is not by itself enough to keep this
+    // a 401.
+    const response = await request(app)
+      .get(`${baseUrl}/users`)
+      .set('x-api-key', 'usr_nosuchkeyatall');
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toContain('INVALID DATA: Invalid API Key');
+  });
+
+  it('still answers 401 to a key of no recognisable kind', async function () {
+    const response = await request(app)
+      .get(`${baseUrl}/users`)
+      .set('x-api-key', 'not-a-prefixed-key');
+
+    expect(response.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## The problem

Authentication reads the database. So does every route behind it. When the
database is unreachable, `authenticateApiKeyMiddleware` catches the resulting
exception and answers **401**:

```ts
} catch (err: any) {
  if (!res.headersSent) {
    return res.status(401).json({
      error: err.message || 'Invalid API Key',
    });
  }
}
```

which produces things like:

```
401 {"error":"connect ECONNREFUSED 127.0.0.1:27017"}
401 {"error":"Operation `users.findOne()` buffering timed out after 10000ms"}
```

The status says the caller sent a bad key. The body says Mongoose could not
reach the database. Only the body is true, and most clients only look at the
status.

Meanwhile `/api/v1/healthcheck` returns 200 unconditionally — it proves the
HTTP listener is up and nothing else.

## Why it matters

I lost most of a day to this. A SPACE instance had been up for fifteen hours,
its healthcheck passing the whole time, with its `mongodb` container stopped.
Every authenticated request came back 401, so the first assumption was a wrong
API key — then a wrong admin password, then a mis-copied organization key. The
healthcheck confirmed, repeatedly, that the service was fine.

Two signals agreeing on the wrong answer is what made it expensive. Either one
alone would have been survivable.

It also defeats an orchestrator: a container that reports healthy while unable
to serve a single request is one Kubernetes or Compose will keep sending
traffic to, and will never restart.

## The change

**Authentication.** `authenticateUserApiKey` and `authenticateOrgApiKey` throw a
typed `InvalidApiKeyError` for the two cases that really are bad credentials
(no such user, no such organization). The catch answers 401 only for those.
Anything else is a `503` with `Retry-After`, because the credential was never
judged — the request did not get that far — and the caller should try again
rather than go looking at their key. The underlying error is logged and
included as `details`.

**Healthcheck.** 503 when Mongoose is not connected, and when it is, a `ping`
before answering 200: `readyState` is what the driver believes, a ping is what
the database says, and the two disagree when a connection has gone stale. The
response now carries `database: "connected" | "disconnected" | "unreachable"`.

## Verification

Stopping the database under a running server, same request both ways:

```
main:
  healthcheck HTTP 200 -> {"message":"Service is up and running!"}
  authed call HTTP 401 -> {"error":"connect ECONNREFUSED ::1:27117, connect ECONNREFUSED 127.0.0.1:27117"}

this PR:
  healthcheck HTTP 503 -> {"message":"Service is up but cannot reach its database.","database":"disconnected"}
  authed call HTTP 503 -> {"error":"Space cannot verify credentials right now.","details":"connect ECONNREFUSED …"}
```

With the database up, both branches behave identically: healthcheck 200, and an
unknown key still 401 — see the correction below, which is where that claim
first went wrong.

`pnpm run build` (`tsc`) passes.

## A note on scope

I have deliberately not touched the other `catch` blocks that map errors to
statuses, nor added a readiness probe distinct from liveness — either could be
worth doing, but this PR is about the one pair of signals that actively
misleads. Happy to extend it if you would like the wider change.



---

## Correction and follow-up commit

**The first version of this PR broke a 401.** I ran the repository's full suite
per file afterwards and `authMiddleware.test.ts` failed:

```
× Should return 401 with non-existent user API key
AssertionError: expected 503 to be 401
```

My original claim above that "an unknown key still 401" was checked by hand
against an organization key and did not hold for the user path. The reason:

```ts
// UserService.findByApiKey
const user = await this.userRepository.findByApiKey(apiKey);
if (!user) {
  throw new Error('INVALID DATA: Invalid API Key');   // reports absence by throwing
}
```

The service never returns nothing for an unknown key — it throws a plain
`Error`. So the `if (!user) throw new InvalidApiKeyError(...)` guard I added was
unreachable, and the real rejection fell through to the new `503` branch.
Narrowing the catch to a dedicated error type is not by itself sufficient when
the failure being narrowed away is signalled the same way.

The follow-up commit wraps both credential lookups in one place that tells the
codebase's own convention apart from everything else — `INVALID DATA:` is the
prefix this repository already uses for a caller's mistake, so it stays a 401,
and anything else is the database being unable to answer:

```ts
async function rejectionOrOutage<T>(lookup: () => Promise<T>, absent: string): Promise<T> {
  let found: T;
  try {
    found = await lookup();
  } catch (err: any) {
    if (typeof err?.message === 'string' && err.message.startsWith('INVALID DATA:')) {
      throw new InvalidApiKeyError(err.message);
    }
    throw err;
  }
  if (!found) throw new InvalidApiKeyError(absent);
  return found;
}
```

### Verification of the follow-up

`api/src/test/middlewares/authOutage.test.ts` is new and pins **both**
directions, since the whole change is about the boundary between them:

```
✓ src/test/middlewares/authOutage.test.ts (4 tests)
  ✓ answers 503, not 401, when the lookup fails
  ✓ asks the caller to try again
  ✓ still answers 401 to a key that was read and rejected
  ✓ still answers 401 to a key of no recognisable kind
```

Each direction was confirmed load-bearing by reverting the source:

| source reverted to | which tests fail |
| --- | --- |
| the blanket `401` this PR replaces | the two 503 tests |
| this PR without the `INVALID DATA:` classification | the rejected-key 401 test |

The suite this PR broke is green again: `authMiddleware.test.ts`, 68 passed.
`npx tsc --noEmit` is clean.
