### PR TITLE
Accept an expected consumption of zero

### DIFF
--- a/api/src/main/utils/feature-evaluation/featureEvaluation.ts
+++ b/api/src/main/utils/feature-evaluation/featureEvaluation.ts
@@ -226,7 +226,7 @@ function _buildSuccessResult(
         subscriptionContext[limitKey],
         expectedConsumption[limitKey]
       );
-      if (!updatedUsageLevel) {
+      if (updatedUsageLevel === undefined) {
         return _createErrorResult(
           'INVALID_EXPECTED_CONSUMPTION',
           `No expectedConsumption value was provided for limit '${limitKey}', which is used in the evaluation of feature '${featureId}'. Please note that if you provide an expectedConsumption for any limit, you must provide it for all limits involved in that feature's evaluation.`
@@ -250,7 +250,10 @@ function _updateUsageLevel(
   currentUsageLevel: number,
   expectedConsumption?: number
 ): number | undefined {
-  if (!expectedConsumption) {
+  // `undefined` means the caller did not mention this limit, which is the
+  // error the caller is told about. `0` means they mentioned it and it costs
+  // nothing - a different statement, and one a falsy check cannot tell apart.
+  if (expectedConsumption === undefined || expectedConsumption === null) {
     return undefined;
   }
 

--- a/api/src/test/feature-evaluation.zero-consumption.test.ts
+++ b/api/src/test/feature-evaluation.zero-consumption.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateFeature } from '../main/utils/feature-evaluation/featureEvaluation';
+import type {
+  EvaluationContext,
+  FeatureEvaluationResult,
+  PricingContext,
+  SubscriptionContext,
+} from '../main/types/models/FeatureEvaluation';
+
+/**
+ * An expected consumption of zero.
+ *
+ * A caller who provides `expectedConsumption` must provide it for every limit
+ * involved in the feature's evaluation, or be refused. So the only way to say
+ * "this limit takes part in the evaluation but this call does not spend it" is
+ * to pass zero - which two falsy checks rejected as if the limit had been left
+ * out altogether.
+ *
+ * The second of those checks also refused a perfectly ordinary positive
+ * consumption, whenever the current usage level happened to be zero: a brand
+ * new contract, or the first call of a renewal period.
+ */
+
+const FEATURE = 'petclinic-pets';
+const LIMIT = 'petclinic-maxPets';
+
+const EXPRESSION = `subscriptionContext['${LIMIT}'] < pricingContext['usageLimits']['${LIMIT}']`;
+
+const pricingContext: PricingContext = {
+  features: { [FEATURE]: true },
+  usageLimits: { [LIMIT]: 10 },
+};
+
+const evaluationContext: EvaluationContext = { [FEATURE]: EXPRESSION };
+
+/** @param usageLevel what the contract has consumed so far. */
+async function evaluate(usageLevel: number, expectedConsumption?: Record<string, number>) {
+  const subscriptionContext: SubscriptionContext = { [LIMIT]: usageLevel };
+
+  return (await evaluateFeature(FEATURE, pricingContext, subscriptionContext, evaluationContext, {
+    simple: false,
+    expectedConsumption,
+    // No userId, so nothing is written: this is about the verdict, not the
+    // bookkeeping that follows it.
+  })) as FeatureEvaluationResult;
+}
+
+describe('expectedConsumption of zero', () => {
+  it('is accepted, and leaves the usage level where it was', async () => {
+    const result = await evaluate(5, { [LIMIT]: 0 });
+
+    expect(result.error).toBeNull();
+    expect(result.eval).toBe(true);
+    expect(result.used).toEqual({ [LIMIT]: 5 });
+  });
+
+  it('is accepted on a contract that has consumed nothing yet', async () => {
+    // Both zeroes at once: the usage level and the consumption. This is the
+    // case a `!updatedUsageLevel` check gets wrong even after `0 + 0` has been
+    // computed correctly.
+    const result = await evaluate(0, { [LIMIT]: 0 });
+
+    expect(result.error).toBeNull();
+    expect(result.used).toEqual({ [LIMIT]: 0 });
+  });
+
+  it('is not reported as a missing value', async () => {
+    const result = await evaluate(0, { [LIMIT]: 0 });
+
+    expect(result.error?.code).not.toBe('INVALID_EXPECTED_CONSUMPTION');
+  });
+});
+
+describe('expectedConsumption on an untouched usage level', () => {
+  it('adds to a usage level of zero', async () => {
+    // Not about zero consumption at all: a plain consumption of 1 on a brand
+    // new contract. `1` is truthy, but only because the addition happens to
+    // leave a truthy total.
+    const result = await evaluate(0, { [LIMIT]: 1 });
+
+    expect(result.error).toBeNull();
+    expect(result.used).toEqual({ [LIMIT]: 1 });
+  });
+
+  it('adds to a non-zero usage level, as before', async () => {
+    const result = await evaluate(5, { [LIMIT]: 3 });
+
+    expect(result.used).toEqual({ [LIMIT]: 8 });
+  });
+});
+
+describe('expectedConsumption that really is missing', () => {
+  it('is still refused when the limit is left out', async () => {
+    const result = await evaluate(5, { 'petclinic-someOtherLimit': 1 });
+
+    expect(result.error?.code).toBe('INVALID_EXPECTED_CONSUMPTION');
+  });
+
+  it('reports the current usage level when no consumption is given at all', async () => {
+    const result = await evaluate(5, undefined);
+
+    expect(result.error).toBeNull();
+    expect(result.used).toEqual({ [LIMIT]: 5 });
+  });
+
+  it('treats an empty object as no consumption', async () => {
+    const result = await evaluate(5, {});
+
+    expect(result.error).toBeNull();
+    expect(result.used).toEqual({ [LIMIT]: 5 });
+  });
+});


### PR DESCRIPTION
## The problem

`expectedConsumption` cannot express "this limit takes part in the evaluation, but this call spends nothing of it".

When a caller provides `expectedConsumption`, `evaluateFeature` requires a value for **every** limit involved in the feature's expression, or it refuses the call:

> Please note that if you provide an expectedConsumption for any limit, you must provide it for all limits involved in that feature's evaluation.

So the only value a caller can give for a limit they are not spending is `0`. Two falsy checks in `featureEvaluation.ts` rejected exactly that, and reported it with the message meant for a caller who forgot the limit entirely.

The second check is the wider bug: it tests the *sum*, not the input, so it also refuses an ordinary positive consumption whenever the current usage level is still `0` — the state of every contract on its first call, and of every renewable limit right after it resets.

```ts
// _buildSuccessResult
const updatedUsageLevel = _updateUsageLevel(subscriptionContext[limitKey], expectedConsumption[limitKey]);
if (!updatedUsageLevel) {          // 0 + 0 === 0, and 0 is falsy
  return _createErrorResult('INVALID_EXPECTED_CONSUMPTION', ...);
}

// _updateUsageLevel
if (!expectedConsumption) {        // cannot tell 0 from undefined
  return undefined;
}
```

## Reproduction

A feature whose expression involves one limit, evaluated with `simple: false`:

| usage level | expectedConsumption | expected | before this PR |
| --- | --- | --- | --- |
| 5 | `{ maxPets: 0 }` | `used: 5`, no error | `INVALID_EXPECTED_CONSUMPTION` |
| 0 | `{ maxPets: 0 }` | `used: 0`, no error | `INVALID_EXPECTED_CONSUMPTION` |
| 0 | `{ maxPets: 1 }` | `used: 1`, no error | ok (only because `0 + 1` is truthy) |

The first row is the "check without charging" case — asking whether an action *would* be allowed. The second is the same request against a contract that has not consumed anything yet. Neither has anything to do with a missing value, which is what the caller is told.

This also affects any feature whose expression involves several limits where only some are actually spent: the caller must name them all, and the ones that cost nothing can only be declared as zero.

## The change

Two lines in `api/src/main/utils/feature-evaluation/featureEvaluation.ts`:

- `_updateUsageLevel` distinguishes an absent value from zero: `expectedConsumption === undefined || expectedConsumption === null` instead of `!expectedConsumption`.
- `_buildSuccessResult` checks the returned value for `undefined` instead of for falsiness, so a computed usage level of `0` is a result, not a failure.

The genuinely-missing case is unchanged: a limit absent from `expectedConsumption` still yields `INVALID_EXPECTED_CONSUMPTION`, and the separate `throw` in `evaluateFeature` that guards the write path is untouched.

## Verification

New file `api/src/test/feature-evaluation.zero-consumption.test.ts` — 8 tests, driving the public `evaluateFeature` rather than the private helpers:

```
✓ src/test/feature-evaluation.zero-consumption.test.ts (8 tests)
  Tests  8 passed (8)
```

Each of the two source changes was reverted independently to confirm the tests are load-bearing: without the `_buildSuccessResult` fix, 2 of the 8 fail; without the `_updateUsageLevel` fix, 3 fail.

The existing suite for this module is unaffected:

```
✓ src/test/feature-evaluation.test.ts (26 tests)
  Tests  26 passed (26)
```

`npx tsc --noEmit` is clean.

## Scope

Two lines plus a test file. No API shape, no schema and no persisted data changes; a request that worked before still works, and the newly accepted values previously produced an error rather than a different result — so nothing that currently succeeds changes behaviour.
